### PR TITLE
fix: update label for Farsan in navigation links

### DIFF
--- a/constants/index.ts
+++ b/constants/index.ts
@@ -39,7 +39,7 @@ export const NavLinks = [
   },
   {
     route: "/farsan",
-    label: "Farsan",
+    label: "Farsan & Mukhvas",
   },
   {
     route: "/organic",


### PR DESCRIPTION
- Changed the label for the Farsan route to "Farsan & Mukhvas" for improved clarity and accuracy in navigation.